### PR TITLE
Register the workflow in the default branch instead of the master branch.

### DIFF
--- a/.github/workflows/fdroid.yml
+++ b/.github/workflows/fdroid.yml
@@ -1,0 +1,45 @@
+name: Generate F-Droid repo
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  apps:
+    name: "Generate repo from apps listing"
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: fdroid
+
+      - name: Create basic directory structure
+        run: mkdir -p fdroid/repo
+
+      - name: Restore correct mtime
+        run: |
+          sudo apt install git-restore-mtime 
+          git restore-mtime
+
+      - name: Install F-Droid server software
+        run: |
+         sudo add-apt-repository ppa:fdroid/fdroidserver
+         sudo apt-get update
+         sudo apt-get install fdroidserver
+
+      - name: Set up repo secrets
+        run: |
+          echo "${{ secrets.KEYSTORE_P12 }}" | base64 -d - > fdroid/keystore.p12
+          echo "${{ secrets.CONFIG_YML }}" | base64 -d - >> fdroid/config.yml
+
+      - uses: actions/setup-go@v2
+        name: Set up Go
+        with:
+          go-version: '^1.17.0' 
+        
+      - name: Run update script
+        run: bash update.sh 2>&1
+        env:
+          GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}


### PR DESCRIPTION
This will allow the process in #22 to be finished, because ANNOYING STUFF

<details>
<summary>whining about how I can't get the workflow defined in the fdroid branch to keep the logic with the code</summary>

>

This started out quite simple until I tried to take a screenshots and realized that my actions tab shows no actions available. I've tried a whole bunch of stuff and figured out:

1. If I create a `workflow1` in the fdroid branch, it doesn't show up in the actions tab (by name)
2. if I create a `workflow1` in the default branch, it shows up (by name)
3. If I create a `workflow1` with the same name in both branches, it shows up correctly (by name) and allows me to choose which branch I want to run it in.
4. If I create a `workflow1` in the default branch and a `workflow2` in the fdroid branch, the actions tab shows `workflow1` and `.github/workflows/workflow2`. It shows the path for workflow2, rather than the name, though IIRC the workflow worked correctly
5. I can't get automated on:release actions to run from another branch *no matter what I do*.
  - I think you might need to create your release from the branch you want the action to run on. In other words, if you create the workflow in the fdroid branch, it might *only* run when you release from the fdroid branch. See [Triggering a workflow](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow) (*GitHub searches the .github/workflows directory in your repository for workflow files that are present in the associated commit SHA or Git ref of the event.*)
    - I didn't bother to test this, because I don't want releases containing an fdroid repository instead of source code
6. I didn't know any of this until now because until now I've never tried using the release trigger, or working with a repository of source code (so far I've only used actions for releases from other repos, and the default branch has been the one with the repo)
</details>