### PR TITLE
Bug fixes

### DIFF
--- a/Common/Transfers/ProgressUpdatedUIEventArgs.cs
+++ b/Common/Transfers/ProgressUpdatedUIEventArgs.cs
@@ -4,16 +4,17 @@ namespace Seeker
 {
     public class ProgressUpdatedUIEventArgs : EventArgs
     {
-        public ProgressUpdatedUIEventArgs(TransferItem _ti, bool _wasFailed, double _percentComplete, double _avgspeedBytes)
+        public TransferItem TransferItem;
+        public bool WasFailed;
+        public double PercentComplete;
+        public double AverageSpeedBytes;
+
+        public ProgressUpdatedUIEventArgs(TransferItem transferItem, bool wasFailed, double percentComplete, double averageSpeedBytes)
         {
-            ti = _ti;
-            wasFailed = _wasFailed;
-            percentComplete = _percentComplete;
-            avgspeedBytes = _avgspeedBytes;
+            TransferItem = transferItem;
+            WasFailed = wasFailed;
+            PercentComplete = percentComplete;
+            AverageSpeedBytes = averageSpeedBytes;
         }
-        public TransferItem ti;
-        public bool wasFailed;
-        public double percentComplete;
-        public double avgspeedBytes;
     }
 }

--- a/Common/Transfers/ProgressUpdatedUIEventArgs.cs
+++ b/Common/Transfers/ProgressUpdatedUIEventArgs.cs
@@ -4,17 +4,15 @@ namespace Seeker
 {
     public class ProgressUpdatedUIEventArgs : EventArgs
     {
-        public ProgressUpdatedUIEventArgs(TransferItem _ti, bool _wasFailed, bool _fullRefresh, double _percentComplete, double _avgspeedBytes)
+        public ProgressUpdatedUIEventArgs(TransferItem _ti, bool _wasFailed, double _percentComplete, double _avgspeedBytes)
         {
             ti = _ti;
             wasFailed = _wasFailed;
-            fullRefresh = _fullRefresh;
             percentComplete = _percentComplete;
             avgspeedBytes = _avgspeedBytes;
         }
         public TransferItem ti;
         public bool wasFailed;
-        public bool fullRefresh;
         public double percentComplete;
         public double avgspeedBytes;
     }

--- a/Common/Transfers/TransferItemManager.cs
+++ b/Common/Transfers/TransferItemManager.cs
@@ -185,13 +185,11 @@ namespace Seeker
 
         public List<TransferItem> GetBatchSelectedForRetryCondition(TransferUIState uiState, bool selectFailed)
         {
-            bool folderItems = uiState.GroupByFolder && uiState.CurrentlySelectedFolder == null;
             List<TransferItem> tis = new List<TransferItem>();
-            foreach (int pos in uiState.BatchSelectedItems)
+            foreach (ITransferItem iti in uiState.BatchSelectedItems)
             {
-                if (folderItems)
+                if (iti is FolderItem fi)
                 {
-                    var fi = GetItemAtUserIndex(pos, uiState) as FolderItem;
                     foreach (TransferItem ti in fi.TransferItems)
                     {
                         if (selectFailed && ti.Failed)
@@ -204,9 +202,8 @@ namespace Seeker
                         }
                     }
                 }
-                else
+                else if (iti is TransferItem ti)
                 {
-                    var ti = GetItemAtUserIndex(pos, uiState) as TransferItem;
                     if (selectFailed && ti.Failed)
                     {
                         tis.Add(ti);
@@ -705,31 +702,21 @@ namespace Seeker
             List<TransferItem> toCleanUp = new List<TransferItem>();
             lock (AllTransferItems)
             {
-                bool isFolderItems = uiState.GroupByFolder && uiState.CurrentlySelectedFolder == null;
-
-                if (isFolderItems)
+                // Snapshot — we mutate the underlying lists below.
+                var selectedSnapshot = uiState.BatchSelectedItems.ToList();
+                foreach (ITransferItem iti in selectedSnapshot)
                 {
-                    List<FolderItem> toClear = new List<FolderItem>();
-                    foreach (int pos in uiState.BatchSelectedItems)
+                    if (iti is FolderItem fi)
                     {
-                        toClear.Add(GetItemAtUserIndex(pos, uiState) as FolderItem);
+                        toCleanUp.AddRange(ClearAllFromFolderReturnCleanupItems(fi));
                     }
-                    foreach (FolderItem item in toClear)
+                    else if (iti is TransferItem ti)
                     {
-                        toCleanUp.AddRange(ClearAllFromFolderReturnCleanupItems(item));
-                    }
-                }
-                else
-                {
-                    uiState.BatchSelectedItems.Sort();
-                    uiState.BatchSelectedItems.Reverse();
-                    foreach (int pos in uiState.BatchSelectedItems)
-                    {
-                        if (NeedsCleanUp(GetItemAtUserIndex(pos, uiState) as TransferItem))
+                        if (NeedsCleanUp(ti))
                         {
-                            toCleanUp.Add(GetItemAtUserIndex(pos, uiState) as TransferItem);
+                            toCleanUp.Add(ti);
                         }
-                        this.RemoveAtUserIndex(pos, uiState);
+                        Remove(ti);
                     }
                 }
             }
@@ -808,22 +795,14 @@ namespace Seeker
         {
             lock (AllTransferItems)
             {
-                bool isFolderItems = false;
-                if (uiState.GroupByFolder && uiState.CurrentlySelectedFolder == null)
+                foreach (ITransferItem iti in uiState.BatchSelectedItems)
                 {
-                    isFolderItems = true;
-                }
-
-                for (int i = 0; i < uiState.BatchSelectedItems.Count; i++)
-                {
-                    if (isFolderItems)
+                    if (iti is FolderItem fi)
                     {
-                        FolderItem fi = this.GetItemAtUserIndex(uiState.BatchSelectedItems[i], uiState) as FolderItem;
                         CancelFolder(fi, prepareForClear);
                     }
-                    else
+                    else if (iti is TransferItem ti)
                     {
-                        TransferItem ti = this.GetItemAtUserIndex(uiState.BatchSelectedItems[i], uiState) as TransferItem;
                         if (prepareForClear)
                         {
                             if (ti.InProcessing) //let continuation action clear this guy

--- a/Common/Transfers/TransferUIState.cs
+++ b/Common/Transfers/TransferUIState.cs
@@ -6,6 +6,6 @@ namespace Seeker
     {
         public bool GroupByFolder;
         public FolderItem? CurrentlySelectedFolder;
-        public List<int>? BatchSelectedItems;
+        public HashSet<ITransferItem>? BatchSelectedItems;
     }
 }

--- a/Common/Transfers/TransfersViewState.cs
+++ b/Common/Transfers/TransfersViewState.cs
@@ -20,7 +20,7 @@ namespace Seeker
         }
         public FolderItem? CurrentlySelectedDLFolder;
         public FolderItem? CurrentlySelectedUploadFolder;
-        public List<int> BatchSelectedItems = new List<int>();
+        public HashSet<ITransferItem> BatchSelectedItems = new HashSet<ITransferItem>();
         public int ScrollPositionBeforeMovingIntoFolder = int.MinValue;
         public int ScrollOffsetBeforeMovingIntoFolder = int.MinValue;
 

--- a/Seeker/Browse/BrowseAdapter.cs
+++ b/Seeker/Browse/BrowseAdapter.cs
@@ -24,13 +24,23 @@ namespace Seeker
         public BrowseAdapter(List<DataItem> items, BrowseFragment owner)
         {
             Owner = owner;
-            localDataSet = items;
+            // Snapshot: the source list is mutated in-place by BrowseState from
+            // non-UI threads (filter debounce, browse-response handler). Holding
+            // a reference would let RecyclerView's layout pass see the list mid-mutation
+            // and crash in OnBindViewHolder with ArgumentOutOfRangeException.
+            lock (items)
+            {
+                localDataSet = new List<DataItem>(items);
+            }
         }
 
         public BrowseAdapter(List<DataItem> items, BrowseFragment owner, int[]? selectedPos)
         {
             Owner = owner;
-            localDataSet = items;
+            lock (items)
+            {
+                localDataSet = new List<DataItem>(items);
+            }
             if (selectedPos != null && selectedPos.Length != 0)
             {
                 SelectedPositions = selectedPos.ToList();

--- a/Seeker/Main/MainActivity.cs
+++ b/Seeker/Main/MainActivity.cs
@@ -68,7 +68,7 @@ using ActivityFlags = Android.Content.ActivityFlags;
 //\Xamarin\Android\Xamarin.Android.CSharp.targets" />
 namespace Seeker
 {
-    [Activity(Label = "@string/app_name", Theme = "@style/AppTheme.NoActionBar", LaunchMode = Android.Content.PM.LaunchMode.SingleTop, MainLauncher = true, Exported = true/*, WindowSoftInputMode = SoftInput.AdjustNothing*/)]
+    [Activity(Label = "@string/app_name", Theme = "@style/AppTheme.NoActionBar", LaunchMode = Android.Content.PM.LaunchMode.SingleTop, MainLauncher = true, Exported = true, WindowSoftInputMode = Android.Views.SoftInput.AdjustPan)]
     public partial class MainActivity :
         ThemeableActivity, 
         ActivityCompat.IOnRequestPermissionsResultCallback, 

--- a/Seeker/Properties/AndroidManifest.xml
+++ b/Seeker/Properties/AndroidManifest.xml
@@ -1,11 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="128" android:versionName="3.6.0" package="com.companyname.andriodapp1" android:installLocation="auto" android:requestLegacyExternalStorage="true">
-	<application android:allowBackup="true" android:icon="@mipmap/ic_launcher" android:label="@string/app_name" android:supportsRtl="false" android:enableOnBackInvokedCallback="true" android:theme="@style/AppTheme" android:name="com.companyname.Seeker.SeekerApplication" android:localeConfig="@xml/locales_config">
-		<service android:name="com.companyname.Seeker.DownloadService" android:stopWithTask="true"></service>
-		<service android:name="com.companyname.Seeker.SeekerKeepAliveService"></service>
-		<activity android:name="com.companyname.androidapp1.MainActivity" android:windowSoftInputMode="adjustPan"></activity>
-		<activity android:name="com.companyname.Seeker.SettingsActivity" android:parentActivityName="com.companyname.Seeker.MainActivity"></activity>
-		<activity android:name="com.companyname.Seeker.UserListActivity" android:parentActivityName="com.companyname.Seeker.MainActivity"></activity>
+	<application android:allowBackup="true" android:icon="@mipmap/ic_launcher" android:label="@string/app_name" android:supportsRtl="false" android:enableOnBackInvokedCallback="true" android:theme="@style/AppTheme" android:localeConfig="@xml/locales_config">
 		<provider android:name="androidx.core.content.FileProvider" android:authorities="${applicationId}.provider" android:exported="false" android:grantUriPermissions="true">
 			<meta-data android:name="android.support.FILE_PROVIDER_PATHS" android:resource="@xml/provider_paths" />
 		</provider>

--- a/Seeker/Search/SearchTabAdapter.cs
+++ b/Seeker/Search/SearchTabAdapter.cs
@@ -40,12 +40,16 @@ namespace Seeker
 
         private void RemoveSearch_Click(object sender, EventArgs e)
         {
-            int position = (sender as View).FindAncestor<SearchTabView>().ViewHolder.BindingAdapterPosition;
-            if (position < 0 || position >= localDataSet.Count) //in my case this happens if you delete too fast...
+            int tabToRemove = (sender as View).FindAncestor<SearchTabView>().SearchTabId;
+            int position = localDataSet.IndexOf(tabToRemove);
+            if (position < 0) //stale click — item already removed
             {
                 return;
             }
-            int tabToRemove = localDataSet[position];
+            if (!SearchTabHelper.SearchTabCollection.ContainsKey(tabToRemove))
+            {
+                return;
+            }
             bool isWishlist = (SearchTabHelper.SearchTabCollection[tabToRemove].SearchTarget == SearchTarget.Wishlist);
             SearchTabHelper.SearchTabCollection[tabToRemove].CancellationTokenSource?.Cancel();
             if (isWishlist)
@@ -108,12 +112,11 @@ namespace Seeker
 
         private void SearchTabLayout_Click(object sender, EventArgs e)
         {
-            int position = (sender as View).FindAncestor<SearchTabView>().ViewHolder.BindingAdapterPosition;
-            if (position < 0 || position >= localDataSet.Count)
+            int tabToGoTo = (sender as View).FindAncestor<SearchTabView>().SearchTabId;
+            if (!SearchTabHelper.SearchTabCollection.ContainsKey(tabToGoTo))
             {
                 return;
             }
-            int tabToGoTo = localDataSet[position];
             SearchFragment.Instance.GoToTab(tabToGoTo, false);
             SearchTabDialog.Instance.Dismiss();
         }
@@ -156,7 +159,7 @@ namespace Seeker
         private View pillIndicator;
         private View rowBackground;
         public SearchTabViewHolder ViewHolder;
-        public int SearchId = int.MaxValue;
+        public int SearchTabId = int.MaxValue;
         public SearchTabView(Context context, IAttributeSet attrs, int defStyle) : base(context, attrs, defStyle)
         {
             LayoutInflater.From(context).Inflate(Resource.Layout.tab_page_item, this, true);
@@ -183,9 +186,10 @@ namespace Seeker
             rowBackground = FindViewById<View>(Resource.Id.searchTabRowBg);
         }
 
-        public void setItem(int i)
+        public void setItem(int searchTabId)
         {
-            SearchTab searchTab = SearchTabHelper.SearchTabCollection[i];
+            SearchTabId = searchTabId;
+            SearchTab searchTab = SearchTabHelper.SearchTabCollection[searchTabId];
             if (searchTab.SearchTarget == SearchTarget.Wishlist)
             {
                 string timeString = string.Empty;
@@ -231,7 +235,7 @@ namespace Seeker
                 lastSearchTerm.SetTypeface(lastSearchTerm.Typeface, Android.Graphics.TypefaceStyle.Italic);
             }
 
-            bool isActive = (i == SearchTabHelper.CurrentTab);
+            bool isActive = (searchTabId == SearchTabHelper.CurrentTab);
             pillIndicator.SetBackgroundResource(isActive
                 ? Resource.Drawable.search_tab_pill_active
                 : Resource.Drawable.search_tab_pill_inactive);

--- a/Seeker/Search/SearchTabAdapter.cs
+++ b/Seeker/Search/SearchTabAdapter.cs
@@ -19,7 +19,6 @@ namespace Seeker
     {
         private List<int> localDataSet; //tab id's
         public override int ItemCount => localDataSet.Count;
-        private int position = -1;
         public bool ForWishlist = false;
         public override RecyclerView.ViewHolder OnCreateViewHolder(ViewGroup parent, int viewType) //so view Type is a real thing that the recycler adapter knows about.
         {
@@ -41,8 +40,8 @@ namespace Seeker
 
         private void RemoveSearch_Click(object sender, EventArgs e)
         {
-            position = (sender as View).FindAncestor<SearchTabView>().ViewHolder.BindingAdapterPosition;
-            if (position == -1) //in my case this happens if you delete too fast...
+            int position = (sender as View).FindAncestor<SearchTabView>().ViewHolder.BindingAdapterPosition;
+            if (position < 0 || position >= localDataSet.Count) //in my case this happens if you delete too fast...
             {
                 return;
             }
@@ -109,7 +108,11 @@ namespace Seeker
 
         private void SearchTabLayout_Click(object sender, EventArgs e)
         {
-            position = (sender as View).FindAncestor<SearchTabView>().ViewHolder.BindingAdapterPosition;
+            int position = (sender as View).FindAncestor<SearchTabView>().ViewHolder.BindingAdapterPosition;
+            if (position < 0 || position >= localDataSet.Count)
+            {
+                return;
+            }
             int tabToGoTo = localDataSet[position];
             SearchFragment.Instance.GoToTab(tabToGoTo, false);
             SearchTabDialog.Instance.Dismiss();

--- a/Seeker/Services/FileSystemService.cs
+++ b/Seeker/Services/FileSystemService.cs
@@ -625,9 +625,8 @@ namespace Seeker.Services
                 {
                     DocumentFile mFile = CommonHelpers.CreateMediaFile(folderDir1, name);
                     finalUri = mFile.Uri.ToString();
-                    System.IO.Stream stream = SeekerState.ActiveActivityRef.ContentResolver.OpenOutputStream(mFile.Uri);
+                    using System.IO.Stream stream = SeekerState.ActiveActivityRef.ContentResolver.OpenOutputStream(mFile.Uri);
                     stream.Write(bytes.Array, bytes.Offset, bytes.Count);
-                    stream.Close();
                 }
                 else
                 {
@@ -644,8 +643,9 @@ namespace Seeker.Services
                             DocumentFile mFile = CommonHelpers.CreateMediaFile(folderDir1, name);
                             uri = mFile.Uri;
                             finalUri = mFile.Uri.ToString();
-                            System.IO.Stream stream = SeekerState.ActiveActivityRef.ContentResolver.OpenOutputStream(mFile.Uri);
-                            MoveFile(SeekerState.ActiveActivityRef.ContentResolver.OpenInputStream(uriOfIncomplete), stream, uriOfIncomplete, parentUriOfIncomplete);
+                            using System.IO.Stream inStream = SeekerState.ActiveActivityRef.ContentResolver.OpenInputStream(uriOfIncomplete);
+                            using System.IO.Stream stream = SeekerState.ActiveActivityRef.ContentResolver.OpenOutputStream(mFile.Uri);
+                            MoveFile(inStream, stream, uriOfIncomplete, parentUriOfIncomplete);
                         }
                         catch (Exception e)
                         {
@@ -725,8 +725,9 @@ namespace Seeker.Services
                                         finalUri = mFile.Uri.ToString();
                                         Logger.InfoFirebase("retrying: incomplete: " + uriOfIncomplete + " complete: " + finalUri + " parent: " + parentUriOfIncomplete);
                                         //                                        Logger.InfoFirebase("using temp: " +
-                                        System.IO.Stream stream = SeekerState.ActiveActivityRef.ContentResolver.OpenOutputStream(mFile.Uri);
-                                        MoveFile(SeekerState.ActiveActivityRef.ContentResolver.OpenInputStream(uriOfIncomplete), stream, uriOfIncomplete, parentUriOfIncomplete);
+                                        using System.IO.Stream inStream = SeekerState.ActiveActivityRef.ContentResolver.OpenInputStream(uriOfIncomplete);
+                                        using System.IO.Stream stream = SeekerState.ActiveActivityRef.ContentResolver.OpenOutputStream(mFile.Uri);
+                                        MoveFile(inStream, stream, uriOfIncomplete, parentUriOfIncomplete);
                                     }
                                     catch (Exception secondTryErr)
                                     {
@@ -771,15 +772,21 @@ namespace Seeker.Services
 
         public void MoveFile(System.IO.Stream from, System.IO.Stream to, Android.Net.Uri toDelete, Android.Net.Uri parentToDelete)
         {
-            byte[] buffer = new byte[4096];
-            int read;
-            while ((read = from.Read(buffer)) != 0) //C# does 0 for you've reached the end!
+            try
             {
-                to.Write(buffer, 0, read);
+                byte[] buffer = new byte[4096];
+                int read;
+                while ((read = from.Read(buffer)) != 0)
+                {
+                    to.Write(buffer, 0, read);
+                }
+                to.Flush();
             }
-            from.Close();
-            to.Flush();
-            to.Close();
+            finally
+            {
+                from.Close();
+                to.Close();
+            }
 
             if (SettingsActivity.UseTempDirectory() || toDelete.Scheme == "file")
             {
@@ -877,15 +884,21 @@ namespace Seeker.Services
 
         public void MoveFile(Java.IO.FileInputStream from, Java.IO.FileOutputStream to, Java.IO.File toDelete, Java.IO.File parent)
         {
-            byte[] buffer = new byte[4096];
-            int read;
-            while ((read = from.Read(buffer)) != -1) //unlike C# this method does -1 for no more bytes left..
+            try
             {
-                to.Write(buffer, 0, read);
+                byte[] buffer = new byte[4096];
+                int read;
+                while ((read = from.Read(buffer)) != -1) // unlike C# this method does -1 for no more bytes left
+                {
+                    to.Write(buffer, 0, read);
+                }
+                to.Flush();
             }
-            from.Close();
-            to.Flush();
-            to.Close();
+            finally
+            {
+                from.Close();
+                to.Close();
+            }
             if (!toDelete.Delete())
             {
                 Logger.Firebase("LEGACY df.Delete() failed to delete ()");

--- a/Seeker/Settings/SettingsActivity.cs
+++ b/Seeker/Settings/SettingsActivity.cs
@@ -51,7 +51,7 @@ using System.Xml.Serialization;
 
 namespace Seeker
 {
-    [Activity(Label = "SettingsActivity", Theme = "@style/AppTheme.NoActionBar", Exported = false)]
+    [Activity(Label = "SettingsActivity", Theme = "@style/AppTheme.NoActionBar", Exported = false, ParentActivity = typeof(MainActivity))]
     public partial class SettingsActivity : ThemeableActivity //AppCompatActivity is needed to support chaning light / dark mode programmatically...
     {
         private const int CHANGE_WRITE_EXTERNAL = 0x909;

--- a/Seeker/Transfers/TransferActionMode.cs
+++ b/Seeker/Transfers/TransferActionMode.cs
@@ -55,14 +55,13 @@ namespace Seeker
                     menu.FindItem(Resource.Id.retry_all_failed_batch).SetVisible(false);
 
                     List<TransferItem> transfersSelected = new List<TransferItem>();
-                    foreach (int position in ViewState.BatchSelectedItems)
+                    foreach (ITransferItem iti in ViewState.BatchSelectedItems)
                     {
-                        var ti = TransferItems.TransferItemManagerWrapped.GetItemAtUserIndex(position);
-                        if (ti is TransferItem singleTi)
+                        if (iti is TransferItem singleTi)
                         {
                             transfersSelected.Add(singleTi);
                         }
-                        else if (ti is FolderItem folderTi)
+                        else if (iti is FolderItem folderTi)
                         {
                             transfersSelected.AddRange(folderTi.TransferItems);
                         }
@@ -96,11 +95,17 @@ namespace Seeker
                     case Resource.Id.action_cancel_and_clear_all_batch:
                         Logger.InfoFirebase("action_cancel_and_clear_batch Pressed");
                         TransferDebouncer.CancelAndClearAll.Trigger();
+                        // Capture positions BEFORE removal, descending so NotifyItemRemoved
+                        // calls don't reference indices that have already shifted.
+                        var removedPositions = ViewState.BatchSelectedItems
+                            .Select(it => TransferItems.TransferItemManagerWrapped.GetUserIndexForITransferItem(it))
+                            .Where(p => p >= 0)
+                            .OrderByDescending(p => p)
+                            .ToList();
                         TransferItems.TransferItemManagerWrapped.CancelSelectedItems(true);
                         TransferItems.TransferItemManagerWrapped.ClearSelectedItemsAndClean();
-                        var selected = ViewState.BatchSelectedItems.ToArray();
                         ViewState.BatchSelectedItems.Clear();
-                        foreach (int pos in selected)
+                        foreach (int pos in removedPositions)
                         {
                             Adapter.NotifyItemRemoved(pos);
                         }
@@ -109,33 +114,18 @@ namespace Seeker
                         break;
                     case Resource.Id.pause_selected_batch:
                         TransferItems.TransferItemManagerWrapped.CancelSelectedItems(false);
-                        selected = ViewState.BatchSelectedItems.ToArray();
-                        ViewState.BatchSelectedItems.Clear();
-                        foreach (int pos in selected)
-                        {
-                            Adapter.NotifyItemChanged(pos);
-                        }
+                        NotifyChangedAndClear(Adapter);
                         //since all selected stuff is going away. its what Gmail action mode does.
                         TransfersActionMode.Finish();
                         break;
                     case Resource.Id.resume_selected_batch:
                         Frag.RetryAllConditionEntry(false, true);
-                        selected = ViewState.BatchSelectedItems.ToArray();
-                        ViewState.BatchSelectedItems.Clear();
-                        foreach (int pos in selected)
-                        {
-                            Adapter.NotifyItemChanged(pos);
-                        }
+                        NotifyChangedAndClear(Adapter);
                         TransfersActionMode.Finish();
                         break;
                     case Resource.Id.retry_all_failed_batch:
                         Frag.RetryAllConditionEntry(true, true);
-                        selected = ViewState.BatchSelectedItems.ToArray();
-                        ViewState.BatchSelectedItems.Clear();
-                        foreach (int pos in selected)
-                        {
-                            Adapter.NotifyItemChanged(pos);
-                        }
+                        NotifyChangedAndClear(Adapter);
                         TransfersActionMode.Finish();
                         break;
                     case Resource.Id.select_all:
@@ -143,7 +133,11 @@ namespace Seeker
                         int cnt = TransfersActionModeCallback.Adapter.ItemCount;
                         for (int i = 0; i < cnt; i++)
                         {
-                            ViewState.BatchSelectedItems.Add(i);
+                            var iti = TransferItems.TransferItemManagerWrapped.GetItemAtUserIndex(i);
+                            if (iti != null)
+                            {
+                                ViewState.BatchSelectedItems.Add(iti);
+                            }
                         }
 
                         TransfersActionModeCallback.Adapter.NotifyDataSetChanged();
@@ -153,15 +147,21 @@ namespace Seeker
                         return true;
                     case Resource.Id.invert_selection:
                         ForceOutIfZeroSelected = false;
-                        List<int> oldOnes = ViewState.BatchSelectedItems.ToList();
-                        ViewState.BatchSelectedItems.Clear();
-                        List<int> all = new List<int>();
                         int cnt1 = TransfersActionModeCallback.Adapter.ItemCount;
+                        var inverted = new HashSet<ITransferItem>();
                         for (int i = 0; i < cnt1; i++)
                         {
-                            all.Add(i);
+                            var iti = TransferItems.TransferItemManagerWrapped.GetItemAtUserIndex(i);
+                            if (iti != null && !ViewState.BatchSelectedItems.Contains(iti))
+                            {
+                                inverted.Add(iti);
+                            }
                         }
-                        ViewState.BatchSelectedItems = all.Except(oldOnes).ToList();
+                        ViewState.BatchSelectedItems.Clear();
+                        foreach (var iti in inverted)
+                        {
+                            ViewState.BatchSelectedItems.Add(iti);
+                        }
 
                         TransfersActionModeCallback.Adapter.NotifyDataSetChanged();
 
@@ -172,17 +172,31 @@ namespace Seeker
                 return true;
             }
 
+            /// <summary>
+            /// For actions (pause/resume/retry) that mutate items in place: derive each
+            /// selected item's current position, clear the selection, and notify those rows.
+            /// </summary>
+            private static void NotifyChangedAndClear(TransferAdapterRecyclerVersion adapter)
+            {
+                var positions = ViewState.BatchSelectedItems
+                    .Select(it => TransferItems.TransferItemManagerWrapped.GetUserIndexForITransferItem(it))
+                    .Where(p => p >= 0)
+                    .ToList();
+                ViewState.BatchSelectedItems.Clear();
+                foreach (int pos in positions)
+                {
+                    adapter.NotifyItemChanged(pos);
+                }
+            }
+
             public void OnDestroyActionMode(ActionMode mode)
             {
                 SeekerState.ActiveActivityRef?.Window?.SetStatusBarColor(Android.Graphics.Color.Transparent);
 
-                int[] prevSelectedItems = new int[ViewState.BatchSelectedItems.Count];
-                ViewState.BatchSelectedItems.CopyTo(prevSelectedItems);
                 TransfersActionMode = null;
                 ViewState.BatchSelectedItems.Clear();
                 this.Adapter.IsInBatchSelectMode = false;
                 this.Adapter.NotifyDataSetChanged();
-
             }
 
         }

--- a/Seeker/Transfers/TransferEventRouter.cs
+++ b/Seeker/Transfers/TransferEventRouter.cs
@@ -8,11 +8,20 @@ using System;
 
 namespace Seeker.Transfers
 {
+    public class ItemRemovedEventArgs : EventArgs
+    {
+        public TransferItem Item;
+        // Pre-computed via GetUserIndexForTransferItem on the active tab. -1 if the item
+        // belongs to the other tab (downloads vs uploads) or otherwise isn't visible.
+        public int UserIndex;
+    }
+
     // Perform UI Agnostic Actions before routing to UI specific event handlers.
     internal static class TransferEventRouter
     {
         public static EventHandler<TransferItem> StateChangedForItem;
         public static EventHandler<ProgressUpdatedUIEventArgs> ProgressUpdated;
+        public static EventHandler<ItemRemovedEventArgs> ItemRemoved;
 
         public static void Wire(ISoulseekClient client)
         {
@@ -168,6 +177,30 @@ namespace Seeker.Transfers
                             AppNotifications.ShowNotificationForCompletedFolder(relevantItem.FolderName, relevantItem.Username);
                         }
                     }
+
+                    bool shouldAutoClear =
+                        (!isUpload && PreferencesState.AutoClearCompleteDownloads) ||
+                        (isUpload && PreferencesState.AutoClearCompleteUploads);
+                    if (shouldAutoClear)
+                    {
+                        // Pre-compute the on-screen position BEFORE removal; after Remove,
+                        // GetUserIndexForTransferItem can't find it.
+                        int idx = TransferItems.TransferItemManagerWrapped.GetUserIndexForTransferItem(relevantItem);
+                        Action action = () =>
+                        {
+                            TransferItems.TransferItemManagerWrapped.Remove(relevantItem);
+                            TransfersFragment.UpdateBatchSelectedItemsIfApplicable(relevantItem);
+                            ItemRemoved?.Invoke(null, new ItemRemovedEventArgs { Item = relevantItem, UserIndex = idx });
+                        };
+                        if (SeekerState.ActiveActivityRef != null)
+                        {
+                            SeekerState.ActiveActivityRef.RunOnUiThread(action);
+                        }
+                        else
+                        {
+                            action();
+                        }
+                    }
                 }
             }
             else
@@ -186,7 +219,7 @@ namespace Seeker.Transfers
             }
         }
 
-        // Saves periodically. Autoclear if set. Call another ProgressUpdated Event
+        // Saves periodically. Republishes a UI-friendly ProgressUpdated event.
         private static void OnTransferProgressUpdated(object sender, TransferProgressUpdatedEventArgs e)
         {
             //Its possible to get a nullref here IF the system orientation changes..
@@ -223,22 +256,8 @@ namespace Seeker.Transfers
                 relevantItem.RemainingTime = e.Transfer.RemainingTime;
                 relevantItem.AvgSpeed = e.Transfer.AverageSpeed;
 
-                if (((PreferencesState.AutoClearCompleteDownloads && !isUpload) || (PreferencesState.AutoClearCompleteUploads && isUpload)) && System.Math.Abs(percentComplete - 100) < .001) //if 100% complete and autoclear //todo: autoclear on upload
-                {
-
-                    Action action = new Action(() =>
-                    {
-                        TransfersFragment.UpdateBatchSelectedItemsIfApplicable(relevantItem);
-                        TransferItems.TransferItemManagerWrapped.Remove(relevantItem);//TODO: shouldnt we do the corresponding Adapter.NotifyRemoveAt. //this one doesnt need cleaning up, its successful..
-                    });
-                    if (SeekerState.ActiveActivityRef != null)
-                    {
-                        SeekerState.ActiveActivityRef?.RunOnUiThread(action);
-                    }
-
-                    fullRefresh = true;
-                }
-                else if (System.Math.Abs(percentComplete - 100) < .001)
+                // final-tick UI redraw.
+                if (System.Math.Abs(percentComplete - 100) < .001)
                 {
                     fullRefresh = true;
                 }

--- a/Seeker/Transfers/TransferEventRouter.cs
+++ b/Seeker/Transfers/TransferEventRouter.cs
@@ -249,18 +249,11 @@ namespace Seeker.Transfers
             else
             {
                 TransferItemManager.MarkTransfersDirty();
-                bool fullRefresh = false;
                 double percentComplete = e.Transfer.PercentComplete;
                 relevantItem.Progress = (int)percentComplete;
                 relevantItem.BytesTransferred = e.Transfer.BytesTransferred;
                 relevantItem.RemainingTime = e.Transfer.RemainingTime;
                 relevantItem.AvgSpeed = e.Transfer.AverageSpeed;
-
-                // final-tick UI redraw.
-                if (System.Math.Abs(percentComplete - 100) < .001)
-                {
-                    fullRefresh = true;
-                }
 
                 bool wasFailed = false;
                 if (percentComplete != 0)
@@ -274,7 +267,7 @@ namespace Seeker.Transfers
 
                 }
 
-                ProgressUpdated?.Invoke(null, new ProgressUpdatedUIEventArgs(relevantItem, wasFailed, fullRefresh, percentComplete, e.Transfer.AverageSpeed));
+                ProgressUpdated?.Invoke(null, new ProgressUpdatedUIEventArgs(relevantItem, wasFailed, percentComplete, e.Transfer.AverageSpeed));
             }
         }
 

--- a/Seeker/Transfers/TransferItemViews.cs
+++ b/Seeker/Transfers/TransferItemViews.cs
@@ -215,7 +215,7 @@ namespace Seeker
             {
                 actionContainer.Visibility = ViewStates.Visible;
                 selectionCheckbox.Visibility = ViewStates.Visible;
-                bool isSelected = TransfersViewState.Instance.BatchSelectedItems.Contains(this.ViewHolder.AbsoluteAdapterPosition);
+                bool isSelected = TransfersViewState.Instance.BatchSelectedItems.Contains(item);
                 selectionCheckbox.SetImageResource(isSelected ? Resource.Drawable.check_circle : Resource.Drawable.check_circle_outline);
                 this.Background = isSelected ? Resources.GetDrawable(Resource.Color.batchSelectHighlight, null) : null;
             }
@@ -949,7 +949,7 @@ namespace Seeker
             {
                 actionContainer.Visibility = ViewStates.Visible;
                 selectionCheckbox.Visibility = ViewStates.Visible;
-                bool isSelected = TransfersViewState.Instance.BatchSelectedItems.Contains(this.ViewHolder.AbsoluteAdapterPosition);
+                bool isSelected = TransfersViewState.Instance.BatchSelectedItems.Contains(item);
                 selectionCheckbox.SetImageResource(isSelected ? Resource.Drawable.check_circle : Resource.Drawable.check_circle_outline);
                 this.Background = isSelected ? Resources.GetDrawable(Resource.Color.batchSelectHighlight, null) : null;
             }

--- a/Seeker/Transfers/TransfersFragment.cs
+++ b/Seeker/Transfers/TransfersFragment.cs
@@ -1163,7 +1163,7 @@ namespace Seeker
             }
             if (e.fullRefresh)
             {
-                Activity?.RunOnUiThread(refreshListViewSafe); //in case of rotation it is the ACTIVITY which will be null!!!!
+                Activity?.RunOnUiThread(refreshListViewSafe);
                 return;
             }
             try
@@ -1232,6 +1232,7 @@ namespace Seeker
         {
             Seeker.Transfers.TransferEventRouter.StateChangedForItem += TransferStateChangedItem;
             Seeker.Transfers.TransferEventRouter.ProgressUpdated += TransferProgressUpdated;
+            Seeker.Transfers.TransferEventRouter.ItemRemoved += OnRouterItemRemoved;
             UploadService.TransferAddedUINotify += MainActivity_TransferAddedUINotify; //todo this should eventually be for downloads too.
             DownloadService.Instance.TransferItemQueueUpdated += TransferQueueStateChanged;
 
@@ -1278,9 +1279,35 @@ namespace Seeker
         {
             Seeker.Transfers.TransferEventRouter.ProgressUpdated -= TransferProgressUpdated;
             Seeker.Transfers.TransferEventRouter.StateChangedForItem -= TransferStateChangedItem;
+            Seeker.Transfers.TransferEventRouter.ItemRemoved -= OnRouterItemRemoved;
             DownloadService.Instance.TransferItemQueueUpdated -= TransferQueueStateChanged;
             UploadService.TransferAddedUINotify -= MainActivity_TransferAddedUINotify;
             base.OnStop();
+        }
+
+        private void OnRouterItemRemoved(object sender, Seeker.Transfers.ItemRemovedEventArgs e)
+        {
+            if (e.UserIndex < 0)
+            {
+                // Item lived on the other tab (downloads vs uploads) — nothing visible to update here.
+                return;
+            }
+            if (recyclerTransferAdapter == null)
+            {
+                return;
+            }
+            bool inFolderGroupedRoot = ViewState.GroupByFolder && !ViewState.CurrentlyInFolder();
+            if (inFolderGroupedRoot)
+            {
+                // GetUserIndexForTransferItem returns the parent folder's index in this mode.
+                // The folder may have collapsed (last item) or just lost one of N items —
+                // NotifyItemChanged is the safe baseline that triggers a rebind either way.
+                recyclerTransferAdapter.NotifyItemChanged(e.UserIndex);
+            }
+            else
+            {
+                recyclerTransferAdapter.NotifyItemRemoved(e.UserIndex);
+            }
         }
 
         private void SeekerState_DownloadAddedUINotify(object sender, DownloadAddedEventArgs e)

--- a/Seeker/Transfers/TransfersFragment.cs
+++ b/Seeker/Transfers/TransfersFragment.cs
@@ -1161,11 +1161,6 @@ namespace Seeker
             {
                 return;
             }
-            if (e.fullRefresh)
-            {
-                Activity?.RunOnUiThread(refreshListViewSafe);
-                return;
-            }
             try
             {
                 DateTime now = DateTime.UtcNow;

--- a/Seeker/Transfers/TransfersFragment.cs
+++ b/Seeker/Transfers/TransfersFragment.cs
@@ -941,13 +941,15 @@ namespace Seeker
         public static bool ForceOutIfZeroSelected = true;
         public static void ToggleItemBatchSelect(TransferAdapterRecyclerVersion recyclerTransferAdapter, int pos)
         {
-            if (ViewState.BatchSelectedItems.Contains(pos))
+            var item = TransferItems.TransferItemManagerWrapped.GetItemAtUserIndex(pos);
+            if (item == null)
             {
-                ViewState.BatchSelectedItems.Remove(pos);
+                return;
             }
-            else
+            if (!ViewState.BatchSelectedItems.Add(item))
             {
-                ViewState.BatchSelectedItems.Add(pos);
+                // already present → toggle off
+                ViewState.BatchSelectedItems.Remove(item);
             }
             recyclerTransferAdapter.NotifyItemChanged(pos);
             int cnt = ViewState.BatchSelectedItems.Count;
@@ -968,38 +970,28 @@ namespace Seeker
             {
                 return;
             }
-            int userPositionBeingRemoved = TransferItems.TransferItemManagerWrapped.GetUserIndexForTransferItem(ti);
-            if (userPositionBeingRemoved == -1)
+            int prevCount = ViewState.BatchSelectedItems.Count;
+
+            // Direct case (flat or in-folder view): ti itself was selected.
+            ViewState.BatchSelectedItems.Remove(ti);
+
+            // Folder-grouped view: ti's parent folder may have been selected and may now be
+            // empty/removed. Drop any FolderItem that no longer exists in the manager.
+            ViewState.BatchSelectedItems.RemoveWhere(item =>
+                item is FolderItem fi && TransferItems.TransferItemManagerWrapped.GetIndexForFolderItem(fi) == -1);
+
+            if (ViewState.BatchSelectedItems.Count == prevCount)
             {
                 //it is not currently on our screen, perhaps it is in uploads (and we are in downloads) or we are inside a folder (and it is outside)
                 Logger.Debug("batch on, different screen item removed");
                 return;
             }
-            Logger.Debug("batch on, updating: " + userPositionBeingRemoved);
-            //adjust numbers
-            int cnt = ViewState.BatchSelectedItems.Count;
-            for (int i = cnt - 1; i >= 0; i--)
-            {
-                int position = ViewState.BatchSelectedItems[i];
-                if (position < userPositionBeingRemoved)
-                {
-                    continue;
-                }
-                else if (position == userPositionBeingRemoved)
-                {
-                    ViewState.BatchSelectedItems.RemoveAt(i);
-                }
-                else
-                {
-                    ViewState.BatchSelectedItems[i] = position - 1;
-                }
-            }
-            //if there was only 1 and its the one that just finished then take us out of batchSelectedItems
+            Logger.Debug("batch on, updating selection");
             if (ViewState.BatchSelectedItems.Count == 0)
             {
                 TransfersActionMode.Finish();
             }
-            else if (ViewState.BatchSelectedItems.Count != cnt) //if we have 1 less now.
+            else
             {
                 TransfersActionMode.Title = string.Format(SeekerApplication.GetString(Resource.String.Num_Selected), ViewState.BatchSelectedItems.Count.ToString());
                 TransfersActionMode.Invalidate();

--- a/Seeker/Transfers/TransfersFragment.cs
+++ b/Seeker/Transfers/TransfersFragment.cs
@@ -1153,22 +1153,22 @@ namespace Seeker
 
         private void TransferProgressUpdated(object sender, ProgressUpdatedUIEventArgs e)
         {
-            if (e.ti.IsUpload() != ViewState.InUploadsMode)
+            if (e.TransferItem.IsUpload() != ViewState.InUploadsMode)
             {
                 return;
             }
-            if (e.percentComplete == 0)
+            if (e.PercentComplete == 0)
             {
                 return;
             }
             try
             {
                 DateTime now = DateTime.UtcNow;
-                string throttleKey = e.ti.GetThrottleKey();
+                string throttleKey = e.TransferItem.GetThrottleKey();
                 DateTime lastUpdated = ProgressUpdatedThrottler.GetOrAdd(throttleKey, now);
                 bool isNew = lastUpdated == now;
                 bool shouldUpdate = isNew
-                    || e.wasFailed
+                    || e.WasFailed
                     || now.Subtract(lastUpdated).TotalMilliseconds > THROTTLE_PROGRESS_UPDATED_RATE;
 
                 if (!shouldUpdate)
@@ -1180,13 +1180,13 @@ namespace Seeker
 
                 Activity?.RunOnUiThread(() =>
                 {
-                    int index = TransferItems.TransferItemManagerWrapped.GetUserIndexForTransferItem(e.ti);
+                    int index = TransferItems.TransferItemManagerWrapped.GetUserIndexForTransferItem(e.TransferItem);
                     if (index == -1)
                     {
                         Logger.Debug("Index is -1 TransferProgressUpdated");
                         return;
                     }
-                    refreshItemProgress(index, e.ti.GetProgressForPresentation(), e.ti, e.wasFailed, e.avgspeedBytes);
+                    refreshItemProgress(index, e.TransferItem.GetProgressForPresentation(), e.TransferItem, e.WasFailed, e.AverageSpeedBytes);
                 });
             }
             catch (System.Exception error)

--- a/Seeker/Users/EditUserInfoActivity.cs
+++ b/Seeker/Users/EditUserInfoActivity.cs
@@ -223,7 +223,7 @@ namespace Seeker
                         SeekerApplication.Toaster.ShowToast(SeekerApplication.GetString(Resource.String.error_image_too_large), ToastLength.Long);
                         return;
                     }
-                    System.IO.Stream inputStream = this.ContentResolver.OpenInputStream(data.Data);
+                    using System.IO.Stream inputStream = this.ContentResolver.OpenInputStream(data.Data);
 
                     //copy the file to our internal storage
 
@@ -242,20 +242,18 @@ namespace Seeker
                     PreferencesState.UserInfoPictureName = name;
                     PreferencesManager.SaveUserInfoPictureName();
                     Java.IO.File fileForOurInternalStorage = new Java.IO.File(user_info_dir, name);
-                    System.IO.Stream outputStream = this.ContentResolver.OpenOutputStream(AndroidX.DocumentFile.Provider.DocumentFile.FromFile(fileForOurInternalStorage).Uri, "w");
+                    using System.IO.Stream outputStream = this.ContentResolver.OpenOutputStream(AndroidX.DocumentFile.Provider.DocumentFile.FromFile(fileForOurInternalStorage).Uri, "w");
 
                     //this doesnt work btw due to the interal uri not being a SAF uri.
                     //Android.Provider.DocumentsContract.CopyDocument(this.ContentResolver, data.Data, AndroidX.DocumentFile.Provider.DocumentFile.FromFile(f).Uri);
 
                     byte[] buffer = new byte[4096];
                     int read;
-                    while ((read = inputStream.Read(buffer)) != 0) //C# does 0 for you've reached the end!
+                    while ((read = inputStream.Read(buffer)) != 0)
                     {
                         outputStream.Write(buffer, 0, read);
                     }
-                    inputStream.Close();
                     outputStream.Flush();
-                    outputStream.Close();
 
                     //get name of this one and delete the last one...
 

--- a/Seeker/Users/UserInfoResponder.cs
+++ b/Seeker/Users/UserInfoResponder.cs
@@ -71,7 +71,7 @@ namespace Seeker
                 return null;
             }
             DocumentFile documentFile = DocumentFile.FromFile(userInfoPic);
-            System.IO.Stream imageStream = SeekerApplication.ApplicationContext.ContentResolver.OpenInputStream(documentFile.Uri);
+            using System.IO.Stream imageStream = SeekerApplication.ApplicationContext.ContentResolver.OpenInputStream(documentFile.Uri);
             byte[] picFile = new byte[imageStream.Length];
             imageStream.Read(picFile, 0, (int)imageStream.Length);
             return picFile;

--- a/Seeker/Users/UserListActivity.cs
+++ b/Seeker/Users/UserListActivity.cs
@@ -37,7 +37,7 @@ using System.Threading.Tasks;
 using Common;
 namespace Seeker
 {
-    [Activity(Label = "UserListActivity", Theme = "@style/AppTheme.NoActionBar", Exported = false)]
+    [Activity(Label = "UserListActivity", Theme = "@style/AppTheme.NoActionBar", Exported = false, ParentActivity = typeof(MainActivity))]
     public class UserListActivity : ThemeableActivity
     {
         public override bool OnCreateOptionsMenu(IMenu menu)

--- a/UnitTestCommon/TransferItemManagerTests.cs
+++ b/UnitTestCommon/TransferItemManagerTests.cs
@@ -558,7 +558,7 @@ namespace UnitTestCommon
             var uiState = new TransferUIState
             {
                 GroupByFolder = false,
-                BatchSelectedItems = new List<int> { 0, 2 },
+                BatchSelectedItems = new HashSet<ITransferItem> { ti1, ti3 },
             };
 
             manager.CancelSelectedItems(uiState);


### PR DESCRIPTION
- Fixed crash where handwritten activity names in the Android manifest didn't match the auto-generated .NET-for-Android names (ClassNotFoundException). 
- Fixed a race condition crash in the Search Tabs list, Browse List
- Fixed transfer list selection bugs when items were added or removed during multi-select, the wrong rows could end up selected (or selections could go out of bounds). Track actual item.
- Remove "progress > 99.9%" hack.  Remove force full refresh hack.
- Dispose of Streams deterministically instead of waiting on GC.
- Stable IDs instead of tracking indices.