### PR TITLE
Fix persistance issues

### DIFF
--- a/Common/Transfers/TransferPersistence.cs
+++ b/Common/Transfers/TransferPersistence.cs
@@ -98,7 +98,7 @@ namespace Seeker
         /// </summary>
         public static (string downloads, string uploads)? SaveTransferItems(bool force = false, int maxSecondsUpdate = 0)
         {
-            if (force || (TransferItemManager.TransfersDirty && DateTime.UtcNow.Subtract(transfersLastSavedTime).TotalSeconds > maxSecondsUpdate))
+            if (force || (TransferItemManager.TransfersDirty && DateTime.UtcNow.Subtract(transfersLastSavedTime).TotalSeconds >= maxSecondsUpdate))
             {
                 if (TransferItems.TransferItemManagerDL?.AllTransferItems == null)
                 {

--- a/Seeker/Helpers/ForegroundLifecycleTracker.cs
+++ b/Seeker/Helpers/ForegroundLifecycleTracker.cs
@@ -152,15 +152,7 @@ namespace Seeker
 
                 //snapshot state that is not saved at mutation time (e.g. transient user list
                 //status / data fields from Server)
-                string userListSerialized = null;
-                if (CommonState.UserList != null)
-                {
-                    lock (CommonState.UserList)
-                    {
-                        userListSerialized = SerializationHelper.SaveUserListToString(CommonState.UserList);
-                    }
-                }
-                PreferencesManager.SaveOnPauseState(userListSerialized);
+                PreferencesManager.SaveBulkState();
                 TransferPersistenceWrapper.SaveTransferItems();
             }
 

--- a/Seeker/Helpers/ForegroundLifecycleTracker.cs
+++ b/Seeker/Helpers/ForegroundLifecycleTracker.cs
@@ -161,6 +161,7 @@ namespace Seeker
                     }
                 }
                 PreferencesManager.SaveOnPauseState(userListSerialized);
+                TransferPersistenceWrapper.SaveTransferItems();
             }
 
             if (NumberOfActiveActivities == 0 && PreferencesState.AutoAwayOnInactivity)

--- a/Seeker/Helpers/PreferencesManager.cs
+++ b/Seeker/Helpers/PreferencesManager.cs
@@ -250,6 +250,26 @@ namespace Seeker
             }
         }
 
+        public static void SaveTransferViewShowSizes()
+        {
+            lock (SharedPrefLock)
+            {
+                var editor = SeekerState.SharedPreferences.Edit();
+                editor.PutBoolean(KeyConsts.M_TransfersShowSizes, PreferencesState.TransferViewShowSizes);
+                editor.Apply();
+            }
+        }
+
+        public static void SaveTransferViewShowSpeed()
+        {
+            lock (SharedPrefLock)
+            {
+                var editor = SeekerState.SharedPreferences.Edit();
+                editor.PutBoolean(KeyConsts.M_TransfersShowSpeed, PreferencesState.TransferViewShowSpeed);
+                editor.Apply();
+            }
+        }
+
         public static void SaveTransferViewInUploadsMode()
         {
             lock (SharedPrefLock)
@@ -519,6 +539,17 @@ namespace Seeker
             {
                 var editor = SeekerState.SharedPreferences.Edit();
                 editor.PutBoolean(KeyConsts.M_LegacyLanguageMigrated, PreferencesState.LegacyLanguageMigrated);
+                editor.Apply();
+            }
+        }
+
+        public static void SaveDownloadDirectoryUri()
+        {
+            lock (SharedPrefLock)
+            {
+                var editor = SeekerState.SharedPreferences.Edit();
+                editor.PutString(KeyConsts.M_SaveDataDirectoryUri, PreferencesState.SaveDataDirectoryUri);
+                editor.PutBoolean(KeyConsts.M_SaveDataDirectoryUriIsFromTree, PreferencesState.SaveDataDirectoryUriIsFromTree);
                 editor.Apply();
             }
         }
@@ -843,10 +874,27 @@ namespace Seeker
         }
 
         /// <summary>
-        /// Saves the bulk state from MainActivity.OnPause — all PreferencesState fields
-        /// plus a pre-serialized user list string (null to skip).
+        /// Snapshots and saves the bulk not-saved-at-mutation-time state (SaveOnPauseState
+        /// fields + the user list).
         /// </summary>
-        public static void SaveOnPauseState(string userListSerialized)
+        public static void SaveBulkState(bool commit = false)
+        {
+            string userListSerialized = null;
+            if (CommonState.UserList != null)
+            {
+                lock (CommonState.UserList)
+                {
+                    userListSerialized = SerializationHelper.SaveUserListToString(CommonState.UserList);
+                }
+            }
+            SaveOnPauseState(userListSerialized, commit);
+        }
+
+        /// <summary>
+        /// Saves the bulk state — all PreferencesState fields not saved at mutation time
+        /// + a pre-serialized user list string (null to skip).
+        /// </summary>
+        public static void SaveOnPauseState(string userListSerialized, bool commit = false)
         {
             lock (SharedPrefLock)
             {
@@ -884,7 +932,14 @@ namespace Seeker
                     editor.PutString(KeyConsts.M_UserList, userListSerialized);
                 }
 
-                editor.Apply();
+                if (commit)
+                {
+                    editor.Commit();
+                }
+                else
+                {
+                    editor.Apply();
+                }
             }
         }
 

--- a/Seeker/Helpers/PreferencesManager.cs
+++ b/Seeker/Helpers/PreferencesManager.cs
@@ -300,6 +300,18 @@ namespace Seeker
             }
         }
 
+        public static void SaveCredentials()
+        {
+            lock (SharedPrefLock)
+            {
+                var editor = SeekerState.SharedPreferences.Edit();
+                editor.PutBoolean(KeyConsts.M_CurrentlyLoggedIn, PreferencesState.CurrentlyLoggedIn);
+                editor.PutString(KeyConsts.M_Username, PreferencesState.Username);
+                editor.PutString(KeyConsts.M_Password, PreferencesState.Password);
+                editor.Apply();
+            }
+        }
+
         public static void SaveDefaultSearchResultSortAlgorithm()
         {
             lock (SharedPrefLock)

--- a/Seeker/Helpers/PreferencesManager.cs
+++ b/Seeker/Helpers/PreferencesManager.cs
@@ -897,8 +897,10 @@ namespace Seeker
 
         /// <summary>
         /// Saves serialized transfer items, acquiring both SharedPrefLock and TransferStateSaveLock.
+        /// Pass commit=true when the process is about to exit - Apply()'s disk write is queued
+        /// and does not survive JavaSystem.Exit, Commit() blocks until the write hits disk.
         /// </summary>
-        public static void SaveTransferItems(string downloads, string uploads)
+        public static void SaveTransferItems(string downloads, string uploads, bool commit = false)
         {
             lock (SharedPrefLock)
                 lock (TransferStateSaveLock)
@@ -906,7 +908,14 @@ namespace Seeker
                     var editor = SeekerState.SharedPreferences.Edit();
                     editor.PutString(KeyConsts.M_TransferList, downloads);
                     editor.PutString(KeyConsts.M_TransferListUpload, uploads);
-                    editor.Apply();
+                    if (commit)
+                    {
+                        editor.Commit();
+                    }
+                    else
+                    {
+                        editor.Apply();
+                    }
                 }
         }
 

--- a/Seeker/Login/LoginFragment.cs
+++ b/Seeker/Login/LoginFragment.cs
@@ -587,6 +587,7 @@ namespace Seeker
                 {
                     PreferencesState.CurrentlyLoggedIn = false;
                 }
+                PreferencesManager.SaveCredentials();
                 ShowLoginForm(prefill: !clearCreds);
             });
             SeekerState.MainActivityRef.RunOnUiThread(action);
@@ -596,6 +597,7 @@ namespace Seeker
         {
             Logger.Debug("Login succeeded");
             PreferencesState.CurrentlyLoggedIn = true;
+            PreferencesManager.SaveCredentials();
             s_loginInFlight = false;
             ShowLoggedIn();
         }
@@ -610,6 +612,7 @@ namespace Seeker
             {
             }
             PreferencesState.ClearCredentials();
+            PreferencesManager.SaveCredentials();
             ShowLoginForm(prefill: false);
         }
 
@@ -663,7 +666,12 @@ namespace Seeker
                     ShowLoading();
                 }
                 PreferencesState.SetCredentials(usernameTextEdit.Text, passwordTextEdit.Text);
-                if (!alreadyConnected)
+                if (alreadyConnected)
+                {
+                    //normal path saves in OnLoginSucceeded, but that already ran for this session.
+                    PreferencesManager.SaveCredentials();
+                }
+                else
                 {
                     s_loginInFlight = true;
                 }

--- a/Seeker/Main/CloseActivity.cs
+++ b/Seeker/Main/CloseActivity.cs
@@ -44,6 +44,15 @@ namespace Seeker
             //remove this final "closing" activity from task list.
             this.FinishAndRemoveTask();
 
+            //JavaSystem.Exit runs before the looper drains,
+            //so the ACTION_SHUTDOWN service intents and any pending activity OnDestroy (and the
+            //saves they would do) never execute. must be a synchronous Commit - queued Apply()
+            //disk writes die with the process.
+            //This fixes the (user reported and reproduced) issue where if you have finished transfers,
+            //and then hit Clear All Complete which will mark them dirty but not save them,
+            //and then hit Shutdown, they will reappear.
+            TransferPersistenceWrapper.SaveTransferItems(force: false, commit: true);
+
             //actually unload all classes, statics, etc from JVM.
             //the process will still be a "cached background process" that is fine.
             Java.Lang.JavaSystem.Exit(0);

--- a/Seeker/Main/CloseActivity.cs
+++ b/Seeker/Main/CloseActivity.cs
@@ -3,7 +3,6 @@ using Android.Content;
 using Android.OS;
 using AndroidX.AppCompat.App;
 using Seeker.Helpers;
-using System;
 
 namespace Seeker
 {
@@ -28,25 +27,16 @@ namespace Seeker
                 SeekerState.SoulseekClient = null;
             }
 
-            //stop the 3 potential foreground services.
-            Intent intent = new Intent(this, typeof(UploadForegroundService));
-            intent.SetAction(SeekerApplication.ACTION_SHUTDOWN);
-            StartService(intent);
-
-            intent = new Intent(this, typeof(DownloadForegroundService));
-            intent.SetAction(SeekerApplication.ACTION_SHUTDOWN);
-            StartService(intent);
-
-            intent = new Intent(this, typeof(SeekerKeepAliveService));
-            intent.SetAction(SeekerApplication.ACTION_SHUTDOWN);
-            StartService(intent);
+            StopService(new Intent(this, typeof(UploadForegroundService)));
+            StopService(new Intent(this, typeof(DownloadForegroundService)));
+            StopService(new Intent(this, typeof(SeekerKeepAliveService)));
 
             //remove this final "closing" activity from task list.
             this.FinishAndRemoveTask();
 
             //JavaSystem.Exit runs before the looper drains,
-            //so the ACTION_SHUTDOWN service intents and any pending activity OnDestroy (and the
-            //saves they would do) never execute. must be a synchronous Commit - queued Apply()
+            //so pending main-looper work - service callbacks, activity OnDestroy (and the
+            //saves they would do) - never executes. must be a synchronous Commit - queued Apply()
             //disk writes die with the process.
             //This fixes the (user reported and reproduced) issue where if you have finished transfers,
             //and then hit Clear All Complete which will mark them dirty but not save them,

--- a/Seeker/Main/CloseActivity.cs
+++ b/Seeker/Main/CloseActivity.cs
@@ -41,6 +41,9 @@ namespace Seeker
             //This fixes the (user reported and reproduced) issue where if you have finished transfers,
             //and then hit Clear All Complete which will mark them dirty but not save them,
             //and then hit Shutdown, they will reappear.
+            //SaveBulkState also drains any Apply() writes still queued from the OnPause
+            //transition (QueuedWork delays them ~100ms), which would otherwise be lost.
+            PreferencesManager.SaveBulkState(commit: true);
             TransferPersistenceWrapper.SaveTransferItems(force: false, commit: true);
 
             //actually unload all classes, statics, etc from JVM.

--- a/Seeker/Properties/AndroidManifest.xml
+++ b/Seeker/Properties/AndroidManifest.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="136" android:versionName="3.7.4" package="com.companyname.andriodapp1" android:installLocation="auto">
-	<application android:allowBackup="true" android:icon="@mipmap/ic_launcher" android:label="@string/app_name" android:supportsRtl="false" android:enableOnBackInvokedCallback="true" android:theme="@style/AppTheme" android:localeConfig="@xml/locales_config">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="138" android:versionName="3.8.1" package="com.companyname.MOCKDEBUG2" android:installLocation="auto">
+	<application android:allowBackup="true" android:icon="@mipmap/ic_launcher" android:label="MOCKDEBUG" android:supportsRtl="false" android:enableOnBackInvokedCallback="true" android:theme="@style/AppTheme" android:localeConfig="@xml/locales_config">
 		<provider android:name="androidx.core.content.FileProvider" android:authorities="${applicationId}.provider" android:exported="false" android:grantUriPermissions="true">
 			<meta-data android:name="android.support.FILE_PROVIDER_PATHS" android:resource="@xml/provider_paths" />
 		</provider>

--- a/Seeker/Services/StorageState.cs
+++ b/Seeker/Services/StorageState.cs
@@ -34,6 +34,7 @@ namespace Seeker.Services
             {
                 context.ContentResolver.TakePersistableUriPermission(uri, ActivityFlags.GrantWriteUriPermission | ActivityFlags.GrantReadUriPermission);
             }
+            PreferencesManager.SaveDownloadDirectoryUri();
             if (raiseUpdatedEvent)
             {
                 DirectoryUpdatedEvent?.Invoke(null, EventArgs.Empty);
@@ -49,6 +50,7 @@ namespace Seeker.Services
             {
                 context.ContentResolver.TakePersistableUriPermission(uri, ActivityFlags.GrantWriteUriPermission | ActivityFlags.GrantReadUriPermission);
             }
+            PreferencesManager.SaveManualIncompleteDir();
             if (raiseUpdatedEvent)
             {
                 DirectoryUpdatedEvent?.Invoke(null, EventArgs.Empty);

--- a/Seeker/Transfers/TransferPersistence.cs
+++ b/Seeker/Transfers/TransferPersistence.cs
@@ -24,12 +24,12 @@ namespace Seeker
             TransferPersistence.RestoreUploadTransferItems(transferListLegacy, transferListV2);
         }
 
-        public static void SaveTransferItems(bool force = false, int maxSecondsUpdate = 0)
+        public static void SaveTransferItems(bool force = false, int maxSecondsUpdate = 0, bool commit = false)
         {
             var result = TransferPersistence.SaveTransferItems(force, maxSecondsUpdate);
             if (result.HasValue)
             {
-                PreferencesManager.SaveTransferItems(result.Value.downloads, result.Value.uploads);
+                PreferencesManager.SaveTransferItems(result.Value.downloads, result.Value.uploads, commit);
             }
         }
     }

--- a/Seeker/Transfers/TransfersFragment.cs
+++ b/Seeker/Transfers/TransfersFragment.cs
@@ -210,10 +210,12 @@ namespace Seeker
                     return true;
                 case Resource.Id.action_show_size:
                     PreferencesState.TransferViewShowSizes = !PreferencesState.TransferViewShowSizes;
+                    PreferencesManager.SaveTransferViewShowSizes();
                     SetRecyclerAdapter(true);
                     return true;
                 case Resource.Id.action_show_speed:
                     PreferencesState.TransferViewShowSpeed = !PreferencesState.TransferViewShowSpeed;
+                    PreferencesManager.SaveTransferViewShowSpeed();
                     SetRecyclerAdapter(true);
                     return true;
                 case Resource.Id.action_clear_all_complete_and_aborted:


### PR DESCRIPTION
This fixes the (user reported and reproduced) issue where if you have finished transfers, and then hit Clear All Complete which will mark them dirty but not save them, and then hit Shutdown, they will reappear.
In general, Shutdown (which results in `Java.Lang.JavaSystem.Exit(0);`) doesnt wait for anything to save.  And so transfers which were marked dirty but never saved, had potentially infinite time to stay in memory only before the shutdown event.  Now we always save them if they are dirty and commit them synchronously in Shutdown.  
Save the following fields when we mutate them: Login info, download dir, incomplete dir (since again these can be lost on shutdown).
Fix shutdown bug where there is a race condition with StartService, StopService is semantically more correct as well.